### PR TITLE
Update base ubuntu image to 24.04

### DIFF
--- a/soroban_fuzzing/host_env/dockerfile
+++ b/soroban_fuzzing/host_env/dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # Update default packages
 RUN apt-get update


### PR DESCRIPTION
### What:

Update base ubuntu image to 24.04

### Why:
We want to upgrade docker base ubuntu for this project to 24.04.

### Issue:

https://github.com/stellar/ops/issues/4358